### PR TITLE
update rest-client post call to new syntax that accepts verify_ssl

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ gem install ucslib
 
   [1] pry(main)> require 'ucslib'
   => true
-  [2] pry(main)> authjson = { :username => 'admin', :password => 'admin', :ip => '172.16.192.175' }.to_json
+  [2] pry(main)> authjson = { :username => 'admin', :password => 'admin', :ip => '172.16.192.175', :verify_ssl => FALSE}.to_json
   => "{\"username\":\"admin\",\"password\":\"admin\",\"ip\":\"172.16.192.175\"}"
   [3] pry(main)> ucs = UCS.new(authjson)
   Your credentials are username: admin password: admin ip: 172.16.192.175 url https://172.16.192.175/nuova

--- a/lib/ucslib/service/ucs/ucs.rb
+++ b/lib/ucslib/service/ucs/ucs.rb
@@ -40,6 +40,7 @@ class UCS
     username = "#{JSON.parse(authjson)['username']}"
     password = "#{JSON.parse(authjson)['password']}"
     ip       = "#{JSON.parse(authjson)['ip']}"
+    verify_ssl = "#{JSON.parse(authjson)['verify_ssl']}"
     @url      = "https://#{ip}/nuova"
 
     xml_builder = Nokogiri::XML::Builder.new do |xml|
@@ -50,7 +51,7 @@ class UCS
     ucs_response = RestClient::Request.execute(
     	method: :post,
     	url: @url,
-    	verify_ssl: FALSE,
+    	verify_ssl: verify_ssl,
     	payload: aaa_login_xml,
     	headers: {
     		content_type: 'text/xml'

--- a/lib/ucslib/service/ucs/ucs.rb
+++ b/lib/ucslib/service/ucs/ucs.rb
@@ -47,7 +47,14 @@ class UCS
     end
 
     aaa_login_xml = xml_builder.to_xml.to_s
-    ucs_response = RestClient.post(@url, aaa_login_xml, :content_type => 'text/xml').body
+    ucs_response = RestClient::Request.execute(
+    	method: :post,
+    	url: @url,
+    	verify_ssl: FALSE,
+    	payload: aaa_login_xml,
+    	headers: {
+    		content_type: 'text/xml'
+    	}).body
     ucs_login_doc = Nokogiri::XML(ucs_response)
     ucs_login_root = ucs_login_doc.root
     @cookie = ucs_login_root.attributes['outCookie']


### PR DESCRIPTION
Newer versions of rest client do not allow for verify_ssl in the post method and requires the request.execute method to be called. Change only made to the auth post at this point.