### PR TITLE
Global change to REST calls

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,12 @@ To see an example of how ucslib is being used, checkout the ucs and ucs-solo Che
 
 In addition there is a knife plugin that use ucslib as well - https://github.com/velankanisys/knife-ucs
 
-** Version 0.1.8 has been released **
+** Version 0.1.9 has been released **
+
+0.1.9
+
+Updates to allow SSL to be ignored if desired, still defaults to verify_ssl =True
+Abstracted out the Rest post call to allow for easier global changes down the road
 
 0.1.8
 
@@ -44,8 +49,8 @@ gem install ucslib
 
   [1] pry(main)> require 'ucslib'
   => true
-  [2] pry(main)> authjson = { :username => 'admin', :password => 'admin', :ip => '172.16.192.175', :verify_ssl => FALSE}.to_json
-  => "{\"username\":\"admin\",\"password\":\"admin\",\"ip\":\"172.16.192.175\"}"
+  [2] pry(main)> authjson = { :username => 'admin', :password => 'admin', :ip => '172.16.192.175', :verify_ssl => "false"}.to_json
+  => "{\"username\":\"admin\",\"password\":\"admin\",\"ip\":\"172.16.192.175\",\"verify_ssl_\":\"false\"}"
   [3] pry(main)> ucs = UCS.new(authjson)
   Your credentials are username: admin password: admin ip: 172.16.192.175 url https://172.16.192.175/nuova
   => #<UCS:0x007fd269d1eb18>

--- a/lib/ucslib/service/ucs/destroy.rb
+++ b/lib/ucslib/service/ucs/destroy.rb
@@ -36,7 +36,7 @@ module Destroy
 
 		#Post
 		begin
-			RestClient.post(@url, delete_org_XML, :content_type => 'text/xml').body
+			rest_post(delete_org_XML, @url)
 		rescue Exception => e
 			raise "Error #{e}"
 		end
@@ -64,7 +64,7 @@ module Destroy
 
 		#Post
 		begin
-			RestClient.post(@url, delete_vlan_XML, :content_type => 'text/xml').body
+			rest_post(delete_vlan_XML, @url)
 		rescue Exception => e
 			raise "Error #{e}"
 		end

--- a/lib/ucslib/service/ucs/inventory.rb
+++ b/lib/ucslib/service/ucs/inventory.rb
@@ -79,7 +79,7 @@ module Inventory
     #End Build Multi-Class XML
 
     ucs_multi_class_XML = xml_builder.to_xml.to_s
-    ucs_response_multi_class = RestClient.post(@url, ucs_multi_class_XML, :content_type => 'text/xml').body
+    ucs_response_multi_class = rest_post(ucs_multi_class_XML,@url)
 
      #Uncomment the following to create a dump to review and debug elements
      # fh = File.new("ucs_response_multiclass.xml", "w")

--- a/lib/ucslib/service/ucs/manage.rb
+++ b/lib/ucslib/service/ucs/manage.rb
@@ -81,7 +81,7 @@ module Manage
 
 		#Post
 		begin
-			RestClient.post(@url, associate_service_profile_template_to_server_pool_xml, :content_type => 'text/xml').body
+			rest_post(associate_service_profile_template_to_server_pool_xml,@url)
 		rescue Exception => e
 			raise "Error #{e}"
 		end

--- a/lib/ucslib/service/ucs/provision.rb
+++ b/lib/ucslib/service/ucs/provision.rb
@@ -39,7 +39,7 @@ module Provision
       #Post
 
       begin
-        RestClient.post(@url, set_org_xml, :content_type => 'text/xml').body
+        rest_post(set_org_xml,@url)
       rescue Exception => e
         raise "Error #{e}"
       end
@@ -64,7 +64,7 @@ module Provision
 
   		#Post
   		begin
-  			RestClient.post(@url, set_power_policy_xml, :content_type => 'text/xml').body
+  			rest_post(set_power_policy_xml,@url)
   		rescue Exception => e
   			raise "Error #{e}"
   		end
@@ -91,7 +91,7 @@ module Provision
   		#Post
 
   		begin
-  			RestClient.post(@url, set_chassis_discovery_policy_xml, :content_type => 'text/xml').body
+  			rest_post(set_chassis_discovery_policy_xml,@url)
   		rescue Exception => e
   			raise "Error #{e}"
   		end
@@ -119,7 +119,7 @@ module Provision
   		#Post
 
   		begin
-  			RestClient.post(@url, set_time_zone_xml, :content_type => 'text/xml').body
+  			rest_post(set_time_zone_xml,@url)
   		rescue Exception => e
   			raise "Error #{e}"
   		end
@@ -145,7 +145,7 @@ module Provision
   		#Post
 
   		begin
-  			RestClient.post(@url, set_ntp_xml, :content_type => 'text/xml').body
+  			rest_post(set_ntp_xml,@url)
   		rescue Exception => e
   			raise "Error #{e}"
   		end
@@ -175,7 +175,7 @@ module Provision
 
       #Post
       begin
-        RestClient.post(@url, set_local_disk_policy_xml, :content_type => 'text/xml').body
+        rest_post(set_local_disk_policy_xml,@url)
       rescue Exception => e
         raise "Error #{e}"
       end
@@ -204,7 +204,7 @@ module Provision
 
       #Post
       begin
-        RestClient.post(@url, set_syslog_server_xml, :content_type => 'text/xml').body
+        rest_post(set_syslog_server_xml,@url)
       rescue Exception => e
         raise "Error #{e}"
       end
@@ -238,7 +238,7 @@ module Provision
   		#Post
 
   		begin
-  			RestClient.post(@url, set_server_port_xml, :content_type => 'text/xml').body
+  			rest_post(set_server_port_xml,@url)
   		rescue Exception => e
   			raise "Error #{e}"
   		end
@@ -272,7 +272,7 @@ module Provision
   		#Post
 
   		begin
-  			RestClient.post(@url, set_network_uplink_xml, :content_type => 'text/xml').body
+  			rest_post(set_network_uplink_xml,@url)
   		rescue Exception => e
   			raise "Error #{e}"
   		end
@@ -302,7 +302,7 @@ module Provision
 
   		#Post
   		begin
-  			RestClient.post(@url, set_fc_uplink_xml, :content_type => 'text/xml').body
+  			rest_post(set_fc_uplink_xml,@url)
   		rescue Exception => e
   			raise "Error #{e}"
   		end
@@ -345,7 +345,7 @@ module Provision
 
   		#Post
   		begin
-  			RestClient.post(@url, set_port_channel_xml, :content_type => 'text/xml').body
+  			rest_post(set_port_channel_xml,@url)
   		rescue Exception => e
   			raise "Error #{e}"
   		end
@@ -380,7 +380,7 @@ module Provision
 
   		#Post
   		begin
-  			RestClient.post(@url, set_local_boot_policy_xml, :content_type => 'text/xml').body
+  			rest_post(set_local_boot_policy_xml,@url)
   		rescue Exception => e
   			raise "Error #{e}"
   		end
@@ -422,7 +422,7 @@ module Provision
 
   		#Post
   		begin
-  			RestClient.post(@url, set_pxe_boot_policy_xml, :content_type => 'text/xml').body
+  			rest_post(set_pxe_boot_policy_xml,@url)
   		rescue Exception => e
   			raise "Error #{e}"
   		end
@@ -468,7 +468,7 @@ module Provision
 
   		#Post
   		begin
-  			RestClient.post(@url, set_san_boot_policy_xml, :content_type => 'text/xml').body
+  			rest_post(set_san_boot_policy_xml,@url)
   		rescue Exception => e
   			raise "Error #{e}"
   		end
@@ -511,7 +511,7 @@ module Provision
       #Post
 
       begin
-        RestClient.post(@url, set_mgmt_firmware_packagexml, :content_type => 'text/xml').body
+        rest_post(set_mgmt_firmware_packagexml,@url)
       rescue Exception => e
         raise "Error #{e}"
       end
@@ -574,7 +574,7 @@ module Provision
       #Post
 
       begin
-        RestClient.post(@url, set_host_firmware_packagexml, :content_type => 'text/xml').body
+        rest_post(set_host_firmware_packagexml,@url)
       rescue Exception => e
         raise "Error #{e}"
       end
@@ -604,7 +604,7 @@ module Provision
 
   		#Post
   		begin
-  			RestClient.post(@url, set_management_ip_pool_xml, :content_type => 'text/xml').body
+  			rest_post(set_management_ip_pool_xml,@url)
   		rescue Exception => e
   			raise "Error #{e}"
   		end
@@ -632,7 +632,7 @@ module Provision
 
   		#Post
   		begin
-  			RestClient.post(@url, set_vlan_xml, :content_type => 'text/xml').body
+  			rest_post(set_vlan_xml,@url)
   		rescue Exception => e
   			raise "Error #{e}"
   		end
@@ -677,7 +677,7 @@ module Provision
 
   		#Post
   		begin
-  			RestClient.post(@url, set_mac_pool_xml, :content_type => 'text/xml').body
+  			rest_post(set_mac_pool_xml,@url)
   		rescue Exception => e
   			raise "Error #{e}"
   		end
@@ -721,7 +721,7 @@ module Provision
 
   		#Post
   		begin
-  			RestClient.post(@url, set_vnic_template_xml, :content_type => 'text/xml').body
+  			rest_post(set_vnic_template_xml,@url)
   		rescue Exception => e
   			raise "Error #{e}"
   		end
@@ -751,7 +751,7 @@ module Provision
 
   		#Post
   		begin
-  			RestClient.post(@url, set_vsan_xml, :content_type => 'text/xml').body
+  			rest_post(set_vsan_xml,@url)
   		rescue Exception => e
   			raise "Error #{e}"
   		end
@@ -783,7 +783,7 @@ module Provision
 
 		 #Post
 		 begin
-		 	RestClient.post(@url, set_wwnn_pool_xml, :content_type => 'text/xml').body
+		 	rest_post(set_wwnn_pool_xml,@url)
 		 rescue Exception => e
 		 	raise "Error #{e}"
 		 end
@@ -817,7 +817,7 @@ module Provision
 
 		 #Post
 		 begin
-		 	RestClient.post(@url, set_wwpn_pool_xml, :content_type => 'text/xml').body
+		 	rest_post(set_wwpn_pool_xml,@url)
 		 rescue Exception => e
 		 	raise "Error #{e}"
 		 end
@@ -853,7 +853,7 @@ module Provision
 
   		#Post
   		begin
-  			RestClient.post(@url, set_vhba_template_xml, :content_type => 'text/xml').body
+  			rest_post(set_vhba_template_xml,@url)
   		rescue Exception => e
   			raise "Error #{e}"
   		end
@@ -886,7 +886,7 @@ module Provision
 
   		#Post
   		begin
-  			RestClient.post(@url, set_uuid_pool_xml, :content_type => 'text/xml').body
+  			rest_post(set_uuid_pool_xml,@url)
   		rescue Exception => e
   			raise "Error #{e}"
   		end
@@ -958,7 +958,7 @@ module Provision
 
 		 #Post create Service Profile Template
 		 begin
-		 	RestClient.post(@url, set_service_profile_template_xml, :content_type => 'text/xml').body
+		 	rest_post(set_service_profile_template_xml,@url)
 		 rescue Exception => e
 		 	raise "Error #{e}"
 		 end
@@ -986,7 +986,7 @@ module Provision
 
 		 #Post create Service Profiles from Template
 		 begin
-		 	RestClient.post(@url, set_service_profiles_from_template_xml, :content_type => 'text/xml').body
+		 	rest_post(set_service_profiles_from_template_xml,@url)
 		 rescue Exception => e
 		 	raise "Error #{e}"
 		 end
@@ -1067,7 +1067,7 @@ module Provision
 
 		#Post create Service Profiles
 		begin
-			RestClient.post(@url, set_service_profiles_xml, :content_type => 'text/xml').body
+			rest_post(set_service_profiles_xml,@url)
 		rescue Exception => e
 			raise "Error #{e}"
 		end
@@ -1126,7 +1126,7 @@ module Provision
 
       #Post
       begin
-        RestClient.post(@url, set_server_pool_xml, :content_type => 'text/xml').body
+        rest_post(set_server_pool_xml,@url)
       rescue Exception => e
         raise "Error #{e}"
       end

--- a/lib/ucslib/service/ucs/session.rb
+++ b/lib/ucslib/service/ucs/session.rb
@@ -65,7 +65,7 @@ module Session
         end
     aaa_refresh_xml = xml_builder.to_xml.to_s
 
-    ucs_response = RestClient.post(url, aaa_refresh_xml, :content_type => 'text/xml').body
+    ucs_response = rest_post(aaa_refresh_xml,@url)
 
 
     ucs_login_doc = Nokogiri::XML(ucs_response)
@@ -99,7 +99,7 @@ module Session
   	aaaLogoutXML = xml_builder.to_xml.to_s
 
   	begin
-  		RestClient.post(url, aaaLogoutXML, :content_type => 'text/xml').body
+  		rest_post(aaaLogoutXML,@url)
   	rescue Exception => e
   		raise "Error #{e}"
   	end

--- a/lib/ucslib/service/ucs/stats.rb
+++ b/lib/ucslib/service/ucs/stats.rb
@@ -73,7 +73,7 @@ module Stats
         #End Build Multi-Class XML
 
         ucs_multi_class_XML = xml_builder.to_xml.to_s
-        ucs_response_multi_class = RestClient.post(url, ucs_multi_class_XML, :content_type => 'text/xml').body
+        rest_post(ucs_multi_class_XML,@url)
 
         #Uncomment the following to create a dump to review and debug elements
         # fh = File.new("ucs_response_multiclass.xml", "w")

--- a/lib/ucslib/service/ucs/update.rb
+++ b/lib/ucslib/service/ucs/update.rb
@@ -48,7 +48,7 @@ module Update
     #Post
 
     begin
-      RestClient.post(@url, update_host_firmware_packageXML, :content_type => 'text/xml').body
+      rest_post(update_host_firmware_packageXML,@url)
     rescue Exception => e
       raise "Error #{e}"
     end
@@ -85,7 +85,7 @@ module Update
 
     #Post Update Boot Policy on Service Profile Template
     begin
-    	RestClient.post(@url, update_boot_policy_on_service_profile_template_xml, :content_type => 'text/xml').body
+    	rest_post(update_boot_policy_on_service_profile_template_xml,@url)
     rescue Exception => e
     	raise "Error #{e}"
     end

--- a/lib/ucslib/version.rb
+++ b/lib/ucslib/version.rb
@@ -17,5 +17,5 @@
 
 
 module Ucslib
- VERSION = "0.1.8"
+ VERSION = "0.1.9"
 end


### PR DESCRIPTION
This change impacts most files in the lib. I abstracted out the rest call into its own method, changed each rest call to point to the new method. This will allow for easy global changes down the road (one place). I did add in a REST get method in case it can be used down the road (seems like it might be able to).

Allows for users to specify whether they want to ignore SSL certs or not. Default setting is to verify. These changes should be backwards compatible (i.e. if you leave out the :verify_ssl => 'true' JSON item; the lib will assume you want to verify the cert).

Updated the version to allow for a new gem to be built.

I only test some of the functionality (init and discover). May need more thorough testing but all in all is a very repetitious change.

Please let me know, once (and if) you merge, when the new gem is built and uploaded. Thanks!