### PR TITLE
fixed stats fetch issue. Minor oversight in 0.1.9

### DIFF
--- a/lib/ucslib/service/ucs/stats.rb
+++ b/lib/ucslib/service/ucs/stats.rb
@@ -73,7 +73,7 @@ module Stats
         #End Build Multi-Class XML
 
         ucs_multi_class_XML = xml_builder.to_xml.to_s
-        rest_post(ucs_multi_class_XML,@url)
+        ucs_response_multi_class = rest_post(ucs_multi_class_XML,@url)
 
         #Uncomment the following to create a dump to review and debug elements
         # fh = File.new("ucs_response_multiclass.xml", "w")


### PR DESCRIPTION
.fetch(token) failed stating that ucs_response_multi_class wasn't declared. Fixed line 75 in stats.rb, accordingly. 